### PR TITLE
Removed unnecessary cast to Ninject container

### DIFF
--- a/src/MVC4ServicesBook.Web.Common.Tests/MVC4ServicesBook.Web.Common.Tests.csproj
+++ b/src/MVC4ServicesBook.Web.Common.Tests/MVC4ServicesBook.Web.Common.Tests.csproj
@@ -41,6 +41,9 @@
     <Reference Include="Moq">
       <HintPath>..\..\lib\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\lib\Newtonsoft.Json.4.5.10\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\NHibernate.3.3.2.4000\lib\Net35\NHibernate.dll</HintPath>
@@ -55,6 +58,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,6 +72,7 @@
     <Compile Include="LoggingNHibernateSessionAttributeTests.cs" />
     <Compile Include="NinjectDependencyResolverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebContainerManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/MVC4ServicesBook.Web.Common.Tests/WebContainerManagerTests.cs
+++ b/src/MVC4ServicesBook.Web.Common.Tests/WebContainerManagerTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Web.Http;
+using System.Web.Http.Dependencies;
+using Moq;
+using NUnit.Framework;
+
+namespace MVC4ServicesBook.Web.Common.Tests
+{
+    [TestFixture]
+    public class WebContainerManagerTests
+    {
+        private Mock<IDependencyResolver> mockDependencyResolver;
+
+        [SetUp]
+        public void Setup()
+        {
+            mockDependencyResolver = new Mock<IDependencyResolver>();
+            mockDependencyResolver.Setup(x => x.GetService(typeof(ITestableInterface))).Returns(new TestableClass());
+            GlobalConfiguration.Configuration.DependencyResolver = mockDependencyResolver.Object;
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            mockDependencyResolver = null;
+        }
+
+        [Test]
+        public void GetContainer_Returns_Current_Dependency_Resolver()
+        {
+            IDependencyResolver dependencyResolver = WebContainerManager.GetContainer();
+            Assert.IsInstanceOf<IDependencyResolver>(dependencyResolver);
+        }
+
+        [Test]
+        public void Get_Returns_Instance_Of_Class()
+        {
+            ITestableInterface testable = WebContainerManager.Get<ITestableInterface>();
+            Assert.IsInstanceOf<TestableClass>(testable);
+        }
+
+        public interface ITestableInterface { }
+
+        public class TestableClass : ITestableInterface { }
+    }
+}

--- a/src/MVC4ServicesBook.Web.Common.Tests/packages.config
+++ b/src/MVC4ServicesBook.Web.Common.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net45" />
   <package id="log4net" version="2.0.0" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net45" />
   <package id="NHibernate" version="3.3.2.4000" targetFramework="net45" />
   <package id="Ninject" version="3.0.1.10" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />

--- a/src/MVC4ServicesBook.Web.Common/WebContainerManager.cs
+++ b/src/MVC4ServicesBook.Web.Common/WebContainerManager.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Web.Http;
-using Ninject;
+using System.Web.Http.Dependencies;
 
 namespace MVC4ServicesBook.Web.Common
 {
     public static class WebContainerManager
     {
-        public static IKernel GetContainer()
+        public static IDependencyResolver GetContainer()
         {
-            var resolver = GlobalConfiguration.Configuration.DependencyResolver as NinjectDependencyResolver;
-            if (resolver != null)
+            var dependencyResolver = GlobalConfiguration.Configuration.DependencyResolver;
+            if (dependencyResolver != null)
             {
-                return resolver.Container;
+                return dependencyResolver;
             }
 
             throw new InvalidOperationException("NinjectDependencyResolver not being used as the MVC dependency resolver");
@@ -19,7 +19,12 @@ namespace MVC4ServicesBook.Web.Common
 
         public static T Get<T>()
         {
-            return GetContainer().Get<T>();
+            object service = GetContainer().GetService(typeof(T));
+            
+            if (service == null)
+                throw new NullReferenceException(string.Format("Requested service of type {0}, but null was found.", typeof(T).FullName));
+
+            return (T)service;
         }
     }
 }


### PR DESCRIPTION
There is an unnecessary cast to a NinjectDependencyResolver, when just the IDependencyResolver interface would suffice.
